### PR TITLE
Build on non-Windows systems and add Go module support

### DIFF
--- a/api/acl.go
+++ b/api/acl.go
@@ -1,3 +1,5 @@
+//+build windows
+
 package api
 
 import (

--- a/api/acl_test.go
+++ b/api/acl_test.go
@@ -1,3 +1,5 @@
+//+build windows
+
 package api
 
 import (

--- a/api/api.go
+++ b/api/api.go
@@ -1,3 +1,5 @@
+//+build windows
+
 // Windows API functions for manipulating ACLs.
 package api
 

--- a/api/posix.go
+++ b/api/posix.go
@@ -1,0 +1,3 @@
+//+build !windows
+
+package api

--- a/api/secinfo.go
+++ b/api/secinfo.go
@@ -1,3 +1,5 @@
+//+build windows
+
 package api
 
 import (

--- a/api/secinfo_test.go
+++ b/api/secinfo_test.go
@@ -1,3 +1,5 @@
+//+build windows
+
 package api
 
 import (

--- a/api/sid.go
+++ b/api/sid.go
@@ -1,3 +1,5 @@
+//+build windows
+
 package api
 
 import (

--- a/api/sid_test.go
+++ b/api/sid_test.go
@@ -1,3 +1,5 @@
+//+build windows
+
 package api
 
 import (

--- a/apply.go
+++ b/apply.go
@@ -1,3 +1,5 @@
+//+build windows
+
 package acl
 
 import (

--- a/apply_test.go
+++ b/apply_test.go
@@ -1,3 +1,5 @@
+//+build windows
+
 package acl
 
 import (

--- a/chmod.go
+++ b/chmod.go
@@ -1,3 +1,5 @@
+//+build windows
+
 package acl
 
 import (

--- a/chmod_test.go
+++ b/chmod_test.go
@@ -1,3 +1,5 @@
+//+build windows
+
 package acl
 
 import (

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/hectane/go-acl
+
+go 1.12
+
+require golang.org/x/sys v0.0.0-20190529164535-6a60838ec259

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+golang.org/x/sys v0.0.0-20190529164535-6a60838ec259 h1:so6Hr/LodwSZ5UQDu/7PmQiDeS112WwtLvU3lpSPZTU=
+golang.org/x/sys v0.0.0-20190529164535-6a60838ec259/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/posix.go
+++ b/posix.go
@@ -1,0 +1,3 @@
+//+build !windows
+
+package acl

--- a/util.go
+++ b/util.go
@@ -1,3 +1,5 @@
+//+build windows
+
 package acl
 
 import (


### PR DESCRIPTION
This PR:

* Adds build flags so that running `go build github.com/hectane/go-acl` on non-Windows systems will result in an empty package, instead of error-ing.

* Adds Go module support.

cc @zb140 