### PR TITLE
Added Chmod as alias for os.Chmod on non-Windows

### DIFF
--- a/posix.go
+++ b/posix.go
@@ -1,3 +1,8 @@
 //+build !windows
 
 package acl
+
+import "os"
+
+// Chmod is os.Chmod.
+var Chmod = os.Chmod


### PR DESCRIPTION
As suggested by @nathan-osman in [this comment](https://github.com/hectane/go-acl/pull/13#issuecomment-497992331).