### PR TITLE
Fix issue #16 - Error code propagation from api incorrect

### DIFF
--- a/api/acl.go
+++ b/api/acl.go
@@ -85,14 +85,14 @@ type ExplicitAccess struct {
 
 // https://msdn.microsoft.com/en-us/library/windows/desktop/aa379576.aspx
 func SetEntriesInAcl(entries []ExplicitAccess, oldAcl windows.Handle, newAcl *windows.Handle) error {
-	ret, _, err := procSetEntriesInAclW.Call(
+	ret, _, _ := procSetEntriesInAclW.Call(
 		uintptr(len(entries)),
 		uintptr(unsafe.Pointer(&entries[0])),
 		uintptr(oldAcl),
 		uintptr(unsafe.Pointer(newAcl)),
 	)
 	if ret != 0 {
-		return err
+		return windows.Errno(ret)
 	}
 	return nil
 }

--- a/api/secinfo.go
+++ b/api/secinfo.go
@@ -50,7 +50,7 @@ var (
 
 // https://msdn.microsoft.com/en-us/library/windows/desktop/aa446645.aspx
 func GetNamedSecurityInfo(objectName string, objectType int32, secInfo uint32, owner, group **windows.SID, dacl, sacl, secDesc *windows.Handle) error {
-	ret, _, err := procGetNamedSecurityInfoW.Call(
+	ret, _, _ := procGetNamedSecurityInfoW.Call(
 		uintptr(unsafe.Pointer(windows.StringToUTF16Ptr(objectName))),
 		uintptr(objectType),
 		uintptr(secInfo),
@@ -61,14 +61,14 @@ func GetNamedSecurityInfo(objectName string, objectType int32, secInfo uint32, o
 		uintptr(unsafe.Pointer(secDesc)),
 	)
 	if ret != 0 {
-		return err
+		return windows.Errno(ret)
 	}
 	return nil
 }
 
 // https://msdn.microsoft.com/en-us/library/windows/desktop/aa379579.aspx
 func SetNamedSecurityInfo(objectName string, objectType int32, secInfo uint32, owner, group *windows.SID, dacl, sacl windows.Handle) error {
-	ret, _, err := procSetNamedSecurityInfoW.Call(
+	ret, _, _ := procSetNamedSecurityInfoW.Call(
 		uintptr(unsafe.Pointer(windows.StringToUTF16Ptr(objectName))),
 		uintptr(objectType),
 		uintptr(secInfo),
@@ -78,7 +78,7 @@ func SetNamedSecurityInfo(objectName string, objectType int32, secInfo uint32, o
 		uintptr(sacl),
 	)
 	if ret != 0 {
-		return err
+		return windows.Errno(ret)
 	}
 	return nil
 }

--- a/apply_test.go
+++ b/apply_test.go
@@ -5,6 +5,7 @@ package acl
 import (
 	"golang.org/x/sys/windows"
 
+	"errors"
 	"io/ioutil"
 	"os"
 	"testing"
@@ -28,5 +29,25 @@ func TestApply(t *testing.T) {
 	if err == nil {
 		r.Close()
 		t.Fatal("owner able to access file")
+	}
+}
+
+func TestError(t *testing.T) {
+	if _, err := os.Stat(`C:\Folder\That\Doesnt\Exist`); !os.IsNotExist(err) {
+		t.Skip(`Oh come on - C:\Folder\That\Doesnt\Exist exists`)
+	}
+
+	err := Apply(
+		`C:\Folder\That\Doesnt\Exist`,
+		true,
+		true,
+		DenyName(windows.GENERIC_ALL, "CREATOR OWNER"),
+	)
+	if err == nil {
+		t.Fatal("Error expected, none received")
+	}
+	t.Log(err)
+	if !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("Expected to receive an error that \"Is\" ErrNotExist, received %s", err)
 	}
 }


### PR DESCRIPTION
Ensure we are returning the correct thing as an error in the error case

Add a simple test to ensure we return the correct error (before the fix it returned `The operation completed successfully.` as in the bug report)